### PR TITLE
Vim : Update coc.nvim plugin to run 'npm ci' after installation

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -413,7 +413,7 @@ Plug 'iamcco/markdown-preview.nvim', { 'do': 'cd app && yarn install' }
 " -------------------------------------------
 Plug 'jiangmiao/auto-pairs',                { 'commit': '39f06b873a8449af8ff6a3eee716d3da14d63a76' }
 Plug 'antoinemadec/coc-fzf',                { 'commit': '5fae5a15497750483e21fc207aa6005f340f02f2' }
-Plug 'neoclide/coc.nvim',                   { 'commit': 'fab97c7db68f24e5cc3c1cf753d3bd1819beef8f' }
+Plug 'neoclide/coc.nvim',                   { 'commit': '79ccfeaa1db4a3b56767ee7b6b5fc577a5733fef', 'do': 'npm ci' }
 Plug 'github/copilot.vim',                  { 'commit': '3b39e786d865df9ba77fe61624d6ee646528a809' }
 Plug 'dart-lang/dart-vim-plugin',           { 'commit': '928302ec931caf0dcf21835cca284ccd2b192f7b', 'for': 'dart' }
 Plug 'dracula/vim',                         { 'commit': '3e52a0682a53dd7c2c53133d45948f5a49c5fd9a', 'as': 'dracula' }

--- a/vim/functions/plug_get_latest_commits.rb
+++ b/vim/functions/plug_get_latest_commits.rb
@@ -30,6 +30,8 @@ execute_in_vim_dir do
     puts "Plug '#{repo_name}', { 'commit': '#{commit}', 'for': ['javascript', 'typescript'] }"
   when 'rcmdnk/vim-markdown'
     puts "Plug '#{repo_name}', { 'commit': '#{commit}', 'for': 'markdown' }"
+  when 'neoclide/coc.nvim'
+    puts "Plug '#{repo_name}', { 'commit': '#{commit}', 'do': 'npm ci' }"
   when 'iamcco/markdown-preview.nvim'
     # ignore
   else


### PR DESCRIPTION
- Modified .vimrc to add 'do': 'npm ci' for the neoclide/coc.nvim plugin.
- Updated plug_get_latest_commits.rb to handle the new 'do' action for coc.nvim.

modified:   vim/.vimrc
modified:   vim/functions/plug_get_latest_commits.rb