### PR TITLE
Vim : Enhance CopyCurrentPathWithLineNumber to support visual mode

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -1135,8 +1135,16 @@ endfunction
 
 command! -nargs=0 CopyCurrentPathWithLineNumber call CopyCurrentPathWithLineNumber()
 function! CopyCurrentPathWithLineNumber()
-  let @+=expand('%') . ':' . line('.')
-  echo 'copied current path: ' . expand('%') . ':' . line('.')
+  if g:mode == 'n'
+    let l:path = expand('%') . ':' . line('.')
+    let @+ = l:path
+    echo 'copied current path: ' . l:path
+  elseif  g:mode == 'v'
+    let l:lines = range(g:firstline, g:lastline)
+    let l:path = expand('%') . ':' . join(map(l:lines, 'string(v:val)'), ':')
+    let @+ = l:path
+    echo 'copied current path: ' . l:path
+  endif
 endfunction
 
 command! -nargs=0 CopyAbsolutePath call CopyAbsolutePath()

--- a/vim/functions/visual
+++ b/vim/functions/visual
@@ -6,6 +6,7 @@ AddUnderBar
 ModuleToColon
 ColonToModule
 CommaToBreakline
+CopyCurrentPathWithLineNumber
 JsonToHash
 HashToJson
 RocketToHash


### PR DESCRIPTION
- Updated CopyCurrentPathWithLineNumber to handle both normal and visual modes.
- In normal mode, it copies the current file path with the line number.
- In visual mode, it copies the current file path with the range of selected lines.
- Added CopyCurrentPathWithLineNumber to the visual functions list.

modified:   vim/.vimrc
modified:   vim/functions/visual