### PR TITLE
Improve the configs of Copilot Chat

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -446,7 +446,7 @@ Plug 'liuchengxu/vim-which-key',            { 'commit': 'a98626b2bf88d6fc97a8276
 " For CopilotChat
 Plug 'zbirenbaum/copilot.lua',              { 'commit': '86537b286f18783f8b67bccd78a4ef4345679625' }
 Plug 'nvim-lua/plenary.nvim',               { 'commit': 'a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683' }
-Plug 'CopilotC-Nvim/CopilotChat.nvim',      { 'commit': '6f143f210efd1f16d97c077b945c76b7d5fd0f8b' }
+Plug 'CopilotC-Nvim/CopilotChat.nvim',      { 'commit': '92bc7b5e564c23b12b2ed41dd7657fdafe39d95f' }
 call plug#end()
 
 " }}}

--- a/vim/functions/normal
+++ b/vim/functions/normal
@@ -49,5 +49,6 @@ Floaterms
 DeleteFloaterms
 DeleteAnsi
 CopilotChatToggle
+CopilotChatModels
 CopilotChatCommit
 CopilotChatCommitStaged

--- a/vim/functions/normal
+++ b/vim/functions/normal
@@ -50,5 +50,6 @@ DeleteFloaterms
 DeleteAnsi
 CopilotChatToggle
 CopilotChatModels
+CopilotChatReviewClear
 CopilotChatCommit
 CopilotChatCommitStaged

--- a/vim/functions/visual
+++ b/vim/functions/visual
@@ -25,5 +25,4 @@ CopilotChatTests
 CopilotChatDocs
 CopilotChatExplain
 CopilotChatReview
-CopilotChatTranslateJa
-CopilotChatTranslateEn
+CopilotChatTranslate

--- a/vim/lua_scripts/init_copilot_chat.lua
+++ b/vim/lua_scripts/init_copilot_chat.lua
@@ -59,3 +59,14 @@ require('CopilotChat').setup {
     },
   }
 }
+
+local function copilot_chat_review_clear()
+  local ns = vim.api.nvim_create_namespace('copilot_review')
+  vim.diagnostic.reset(ns)
+end
+
+vim.api.nvim_create_user_command(
+  'CopilotChatReviewClear',
+  copilot_chat_review_clear,
+  {}
+)

--- a/vim/lua_scripts/init_copilot_chat.lua
+++ b/vim/lua_scripts/init_copilot_chat.lua
@@ -1,4 +1,13 @@
-require("CopilotChat").setup {
+local custom_system_prompt_for_translate = [[
+You are a proficient bilingual translator specializing in English and Japanese.
+When given input in English, you will translate it accurately into Japanese.
+When given input in Japanese, you will translate it accurately into English.
+Ensure that your translations are clear, contextually appropriate, and maintain the original meaning.
+Pay close attention to cultural nuances, idiomatic expressions, and the overall tone of the text.
+Your goal is to provide seamless and natural translations that are easily understood by native speakers of both languages.
+]]
+
+require('CopilotChat').setup {
   debug = true, -- Enable debugging
   model = 'gpt-4-0125-preview',
 
@@ -23,15 +32,13 @@ require("CopilotChat").setup {
   --     prompt = '/COPILOT_REFACTOR 選択したコードのドキュメントを作成してください。プログラミング言語に最適なドキュメントスタイルを採用してください。',
   --   },
   -- },
+
   prompts = {
-    TranslateJa = {
-      prompt = 'Translate the selected sentence to Japanese, without line number',
-      description = 'Translate the selected code to Japanese',
-      selection = require('CopilotChat.select').visual,
-    },
-    TranslateEn = {
-      prompt = 'Translate the selected sentence to English, without line number',
-      description = 'Translate the selected code to English',
+    Translate = {
+      system_prompt = custom_system_prompt_for_translate,
+      prompt =
+      'Translate the selected text accurately. Output only the translated results. Line numbers are also not required.',
+      description = 'Translate the selected sentence',
       selection = require('CopilotChat.select').visual,
     },
   },


### PR DESCRIPTION
This pull request introduces several changes to improve the translation functionality in the CopilotChat setup. The key changes are:

1. **Addition of a New Translation System Prompt**:
   - Added a new system prompt `COSTOM_SYSTEM_PROMPT_FOR_TRANSLATE` to provide detailed and contextually accurate translations between English and Japanese, with attention to cultural nuances and idiomatic expressions.

2. **Consolidation of Translation Functions**:
   - Combined the separate `CopilotChatTranslateJa` and `CopilotChatTranslateEn` functions into a single `CopilotChatTranslate` function to simplify the translation process and reduce redundancy.

3. **Update to Lua Script**:
   - Modified the `init_copilot_chat.lua` script to include the new system prompt and updated the translation prompts to reflect the consolidated translation function.

### Changes Made:
- **vim/functions/normal**:
  - Added `CopilotChatModels`.

- **vim/functions/visual**:
  - Removed `CopilotChatTranslateJa` and `CopilotChatTranslateEn`.
  - Added `CopilotChatTranslate`.

- **vim/lua_scripts/init_copilot_chat.lua**:
  - Added `COSTOM_SYSTEM_PROMPT_FOR_TRANSLATE`.
  - Updated the `Translate` prompt to use the new system prompt and combined translation functionality.

These changes aim to streamline the translation process within the CopilotChat setup, providing more accurate and contextually appropriate translations while reducing code redundancy.