### PR TITLE
feat(vim): add autocmd for copilot-chat file type

### DIFF
--- a/vim/lua_scripts/init_copilot_chat.lua
+++ b/vim/lua_scripts/init_copilot_chat.lua
@@ -96,3 +96,26 @@ vim.cmd([[
   autocmd CursorHold * lua vim.diagnostic.open_float(nil, {focus=false})
 ]])
 vim.o.updatetime = 500
+
+-- https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/379
+vim.api.nvim_create_autocmd('FileType', {
+  group = augroup,
+  -- pattern = 'copilot-*',
+  pattern = 'copilot-chat',
+  callback = function(info)
+    vim.api.nvim_create_autocmd('InsertEnter', {
+      group = augroup,
+      buffer = info.buf,
+      desc = 'Move to last line',
+      -- nested = true,
+      callback = function()
+        vim.cmd 'normal! 0'
+
+        if vim.fn.search([[\m^##\s\+\S]], 'cnW') > 0 then
+          vim.cmd 'normal! G$'
+          vim.v.char = 'x'
+        end
+      end,
+    })
+  end,
+})


### PR DESCRIPTION
Added an autocmd for the 'copilot-chat' file type to move to the last line when entering insert mode. This change addresses an issue where the cursor would not move to the correct position in copilot-chat buffers. The autocmd checks for a specific pattern and moves the cursor accordingly.

modified:   vim/lua_scripts/init_copilot_chat.lua