### PR TITLE
feat(vim): add nvim-web-devicons and update oil_nvim config

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -425,6 +425,7 @@ Plug 'masakiq/vim-ruby-fold',               { 'commit': 'b8c35810a94bb2976d023ec
 " User Interface
 Plug 'dracula/vim',                         { 'commit': '3e52a0682a53dd7c2c53133d45948f5a49c5fd9a', 'as': 'dracula' }
 Plug 'stevearc/oil.nvim',                   { 'commit': '1360be5fda9c67338331abfcd80de2afbb395bcd' }
+Plug 'nvim-tree/nvim-web-devicons',         { 'commit': '56f17def81478e406e3a8ec4aa727558e79786f3' }
 Plug 'junegunn/fzf.vim',                    { 'commit': 'f7c7b44764a601e621432b98c85709c9a53a7be8' }
 Plug 'voldikss/vim-floaterm',               { 'commit': '4e28c8dd0271e10a5f55142fb6fe9b1599ee6160' }
 Plug 'voldikss/fzf-floaterm',               { 'commit': 'c023f97e49e894ac5649894b7e05505b6df9b055' }

--- a/vim/lua_scripts/init/oil_nvim.lua
+++ b/vim/lua_scripts/init/oil_nvim.lua
@@ -3,6 +3,7 @@ require("oil").setup({
   win_options = {
     winbar = "%!v:lua.get_oil_winbar()",
   },
+  cleanup_delay_ms = 100,
   float = {
     padding = 3,
   },
@@ -21,7 +22,7 @@ vim.api.nvim_create_autocmd("User", {
   pattern = "OilEnter",
   callback = vim.schedule_wrap(function(args)
     local oil = require("oil")
-    oil.set_columns({ "size", "mtime" })
+    oil.set_columns({ "size", "mtime", "icon" })
     if vim.api.nvim_get_current_buf() == args.data.buf and oil.get_cursor_entry() then
       oil.open_preview()
       vim.cmd("set nonumber")


### PR DESCRIPTION
- Added nvim-web-devicons plugin for better file icons.
- Updated oil_nvim configuration to include icon in columns.
- Set cleanup delay to 100ms for improved performance.

modified:   vim/.vimrc
modified:   vim/lua_scripts/init/oil_nvim.lua